### PR TITLE
Replace `available` usage with `type -q`

### DIFF
--- a/functions/config.fish
+++ b/functions/config.fish
@@ -68,9 +68,9 @@ function config -d "Get and set package configuration" -a package action key val
               if not set -q EDITOR
                 echo "No editor in `\$EDITOR` is specified."
 
-                if available vim
+                if type -q vim
                   set editor vim
-                else if available nano
+                else if type -q nano
                   set editor nano
                 else
                   return 1


### PR DESCRIPTION
`available` isn't super fishy, let's use `type -q` instead. it's quiet, it avoids redirection, and @derekstavis likes it better :P
